### PR TITLE
Edge Case Bug Fix: Ignore Phasing In Tokens With 0 Weight And 0 Balance

### DIFF
--- a/service/service_test.go
+++ b/service/service_test.go
@@ -146,10 +146,15 @@ func TestService(t *testing.T) {
 		require.NoError(t, err)
 		poolTokens, err := utils.PoolTokensFor(contract, srv.ew.BC().EthClient())
 		require.NoError(t, err)
+		currBlock, err := srv.ew.BC().CurrentBlock()
+		require.NoError(t, err)
+		balances, weights, supplies, err := srv.GetBalancesWeightsAndSupplies(contract, currBlock, pool.ContractAddress, poolTokens)
+		require.NoError(t, err)
 		info, err := db.GetInfo(pool.Name, pool.LastUpdateAt)
 		require.NoError(t, err)
-		require.Len(t, info.Balances, len(poolTokens))
-		require.Len(t, info.DenormalizedWeights, len(poolTokens))
+		require.Len(t, info.Balances, len(balances))
+		require.Len(t, info.DenormalizedWeights, len(weights))
+		require.Len(t, info.TokenTotalSupplies, len(supplies))
 		// validate non zero weight
 		t.Run("WeightValidation", func(t *testing.T) {
 			for _, weight := range info.DenormalizedWeights {


### PR DESCRIPTION
In certain scenarios tokens may be phased into an index and be included in the output of the "current tokens" but have a weight and/or balance of 0. This can lead to an edge case "bug" where the weights and balances of the asset are increased from zero and in the same block or the next block a swap occurs for that asset. This has the potential for accidentally triggering a circuit break.

Closes https://github.com/indexed-finance/circuit-breaker/issues/17