### PR TITLE
Bug Fixes And Debug Logging Changes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@ circuit-breaker
 sigma-core
 bin
 contracts
+compilers
 
 # regexs
 **/*.yaml

--- a/eventwatcher/handle_log_swaps.go
+++ b/eventwatcher/handle_log_swaps.go
@@ -108,6 +108,8 @@ func (wc *WatchedContract) handleLogSwaps(
 
 					wc.logger.Warn(
 						"price fluctuation outside of acceptable bounds, breaking!",
+						zap.Float64("change.abs", math.Abs(change)),
+						zap.Float64("break.percentage", breakPercentage),
 					)
 
 					// lock the authorizer since bind.TransactOpts is not threadsafe

--- a/service/service.go
+++ b/service/service.go
@@ -192,14 +192,9 @@ func (s *Service) StartWatchers() error {
 	)
 
 	for _, pool := range s.pools {
-		addresses[pool.Name] = pool.ContractAddress
-		spotPriceBreakPercentages[pool.Name] = pool.SpotPriceBreakPercentage
+		addresses[strings.ToLower(pool.Name)] = pool.ContractAddress
+		spotPriceBreakPercentages[strings.ToLower(pool.Name)] = pool.SpotPriceBreakPercentage
 	}
-	s.logger.Info(
-		"break percentages configured",
-		zap.Any("addresses", addresses),
-		zap.Any("spot.prices", spotPriceBreakPercentages),
-	)
 
 	// get the bindings
 	// name -> contract
@@ -232,7 +227,7 @@ func (s *Service) StartWatchers() error {
 			if err := wtchr.Listen(ctx, s.db, s.at, s.auther, bkPercent, s.ew.BC().EthClient()); err != nil {
 				errCh <- err
 			}
-		}(watcher, spotPriceBreakPercentages[watcher.Name()])
+		}(watcher, spotPriceBreakPercentages[strings.ToLower(watcher.Name())])
 	}
 
 	select {

--- a/service/service.go
+++ b/service/service.go
@@ -325,19 +325,8 @@ func (s *Service) StartBlockListener() error {
 							if err != nil {
 								s.logger.Error("failed to get controller contract", zap.Error(err), zap.String("pool", pool.Name), zap.String("token", tok))
 							} else {
-								// get the circuit breaker address
-								circuitBreakerAddr, err := conContract.CircuitBreaker(nil)
-								if err != nil {
-									s.logger.Error("failed to get circuit breaker contract address", zap.Error(err), zap.String("pool", pool.Name), zap.String("token", tok))
-								} else {
-									breaker, err := controller.NewController(circuitBreakerAddr, s.ew.BC().EthClient())
-									if err != nil {
-										s.logger.Error("failed to get circuit breaker contract", zap.Error(err), zap.String("pool", pool.Name), zap.String("token", tok))
-									} else {
-										if err := s.circuitBreakCheck(tok, supply, totalSupplies, pool, breaker); err != nil {
-											s.logger.Error("circuitBreakCheck failed", zap.Error(err), zap.String("pool", pool.Name), zap.String("token", tok))
-										}
-									}
+								if err := s.circuitBreakCheck(tok, supply, totalSupplies, pool, conContract); err != nil {
+									s.logger.Error("circuitBreakCheck failed", zap.Error(err), zap.String("pool", pool.Name), zap.String("token", tok))
 								}
 							}
 						}
@@ -427,7 +416,16 @@ func (s *Service) circuitBreakCheck(
 	// we take the absolute to see if the change is greater than the break percentage
 	// as we want to handle circuit breaks whether the total supply increased or decreases
 	if math.Abs(change) > pool.SupplyBreakPercentage {
-
+		circuitBreakAddr, err := contract.CircuitBreaker(nil)
+		if err != nil {
+			s.logger.Error("failed to get circuit breaker contract address", zap.Error(err))
+			return err
+		}
+		breaker, err := controller.NewController(circuitBreakAddr, s.ew.BC().EthClient())
+		if err != nil {
+			s.logger.Error("failed to get circuit breaker contract binding", zap.Error(err))
+			return err
+		}
 		s.logger.Warn(
 			"token supply fluctuation is greater than minimum break percentage, breaking circuits!",
 			zap.String("pool", pool.Name), zap.String("token", tok),
@@ -443,7 +441,7 @@ func (s *Service) circuitBreakCheck(
 			s.logger.Error("failed to suggest gasprice", zap.Error(err))
 		} else {
 			s.logger.Info("gas price calculated (includes boost)", zap.String("gas.price", gasPrice.String()))
-			s.setPublicSwap(contract, gasPrice, pool.Name, tok, pool.ContractAddress)
+			s.setPublicSwap(breaker, gasPrice, pool.Name, tok, pool.ContractAddress)
 		}
 		// we need to unset the gas price that we overrode the transactor with
 		// so that future uses of this transactor have the gas price set to nil

--- a/service/service.go
+++ b/service/service.go
@@ -195,6 +195,11 @@ func (s *Service) StartWatchers() error {
 		addresses[pool.Name] = pool.ContractAddress
 		spotPriceBreakPercentages[pool.Name] = pool.SpotPriceBreakPercentage
 	}
+	s.logger.Info(
+		"break percentages configured",
+		zap.Any("addresses", addresses),
+		zap.Any("spot.prices", spotPriceBreakPercentages),
+	)
 
 	// get the bindings
 	// name -> contract

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -202,7 +202,7 @@ func TestService(t *testing.T) {
 			common.HexToHash("0x5b6d669d3a27795f6f162737115a5e605157fb26465de23292c55e9739a198e8"),
 		)
 		require.NoError(t, err)
-		fakeSwap := newFakePublicSwap(tx)
+		fakeSwap := newFakePublicSwap(tx, acct.Address)
 		type args struct {
 			token         string
 			supply        interface{}
@@ -373,15 +373,20 @@ func getFakeBalancesWeightsAndSupplies(
 }
 
 type fakePublicSwap struct {
-	tx *types.Transaction
+	tx   *types.Transaction
+	addr common.Address
 }
 
 // returns a fake public swap struct for use with the circuitBreakCheck
 // function, you must provide a transaction hash that has already been mined
-func newFakePublicSwap(tx *types.Transaction) *fakePublicSwap {
+func newFakePublicSwap(tx *types.Transaction, addr common.Address) *fakePublicSwap {
 	return &fakePublicSwap{tx: tx}
 }
 
 func (fpb *fakePublicSwap) SetPublicSwap(opts *bind.TransactOpts, pool common.Address, enabled bool) (*types.Transaction, error) {
 	return fpb.tx, nil
+}
+
+func (fpb *fakePublicSwap) CircuitBreaker(opts *bind.CallOpts) (common.Address, error) {
+	return fpb.addr, nil
 }

--- a/utils/common.go
+++ b/utils/common.go
@@ -13,6 +13,7 @@ import (
 // designed to allow for easier testing
 type Breaker interface {
 	SetPublicSwap(opts *bind.TransactOpts, pool common.Address, enabled bool) (*types.Transaction, error)
+	CircuitBreaker(opts *bind.CallOpts) (common.Address, error)
 }
 
 // GetGasPrice returns a gas price as reported by the oracle, overriding it if it is lower


### PR DESCRIPTION
* adds a fix for excessive infura api calls in the block listener loop. previously i added a change to derive the circuit breaker contract address by retrieving the controller address from the pool, and from the controller address retrieving the circuit breaker address. this happens every single block listener loop which caused a massive amount of infura requests. the change to this was only performing this workflow when we actually need to break a circuit.
* adds some additional logging for break percentage calculations incase of future issues to make debugging easier
* implements a fix where we were not lowercasing the pool name in the config file, but lowercasing it everywhere else. this lead to failing to correctly calculate the configured break percentages for a pool.